### PR TITLE
Added a link to the Facebook group

### DIFF
--- a/accounts.md
+++ b/accounts.md
@@ -7,8 +7,8 @@ This is a list of all the accounts relating to the LGM
 |twitter |[twitter.com/LGMeeting](@LGMeeting) |ale |julien |
 |g+      |https://plus.google.com/110964138103273662022/ |ale |julien |
 |ssh     | |ale, camille| |
-|facebook | |ale | |
-|mailing-lists | [lgm](http://lists.freedesktop.org/mailman/listinfo/libre-graphics-meeting), [lgm-org](http://lists.freedesktop.org/mailman/listinfo/libre-graphics-meeting-org) |ale | |
+|facebook | https://www.facebook.com/groups/libregraphicsmeeting |ale | |
+|mailing-lists | [lgm](http://lists.freedesktop.org/mailman/listinfo/libre-graphics-meeting), [lgm-org](http://lists.freedesktop.org/mailman/listinfo/libre-graphics-meeting-org) |ale |  |
 |titanpad |https://lgm.titanpad.com |ale, camille|all IT + some communication|
 |github |https://github.com/libregraphicsmeeting |ale |IT |
 |youtube |https://www.youtube.com/user/LibreGraphicsMeeting/| g+| |


### PR DESCRIPTION
Here's a list of the actual admins of that group. Didn't know how to insert this in the table. 2ManyAdmins ;) (+me, just added)

![lgm-facebook-group-admins](https://cloud.githubusercontent.com/assets/192539/5666837/f1cc3e6e-9762-11e4-9e7c-4455b9c6f6f8.png)

The way it is set now, is that any member of the group can post. Subscriptions to the group must be validated by an admin before beng valid members.
